### PR TITLE
Correct custom social OG preview in nightshift

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -158,6 +158,7 @@
 }
 
 .gh-og-preview-title {
+    color: #1d2129;
     max-height: 110px;
     overflow: hidden;
     margin-bottom: 5px;
@@ -169,6 +170,7 @@
 }
 
 .gh-og-preview-description {
+    color: #4b4f56;
     max-height: 80px;
     overflow: hidden;
     font-size: 12px;
@@ -201,7 +203,6 @@
 .gh-og-preview-footer-author {
     color: #3b5998;
 }
-
 
 /* Twitter Card Preview */
 .gh-twitter-preview {
@@ -259,8 +260,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-
-
 
 
 /* NEW editor


### PR DESCRIPTION
Closes #8864
Assigns overrides to `og-preview-*` classes. Previously, the classes inherited their color from `body`.

Verified against https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fblog.ghost.org%2Fcustom-social-data%2F

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [ ] Commit message has a short title & issue references
- [ ] Commits are squashed 
- [ ] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
